### PR TITLE
Fix backend Docker entrypoint to index.js

### DIFF
--- a/apps/backend/Dockerfile
+++ b/apps/backend/Dockerfile
@@ -19,4 +19,4 @@ EXPOSE 3000
 
 # Run the app
 ENV NODE_ENV=production
-CMD ["node", "src/server.js"]
+CMD ["node", "src/index.js"]

--- a/apps/backend/package.json
+++ b/apps/backend/package.json
@@ -3,8 +3,8 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "dev": "node --watch src/server.js",
-    "start": "node src/server.js",
+    "dev": "node --watch src/index.js",
+    "start": "node src/index.js",
     "test": "node --test",
     "test:watch": "node --test --watch",
     "test:coverage": "node --test --experimental-test-coverage",


### PR DESCRIPTION
## Summary
- point the backend Docker CMD to src/index.js so the container boots successfully
- update npm dev/start scripts to launch src/index.js as the app entrypoint

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e9697564f8832d8f0f5ed86b0b231f