### PR TITLE
Add coverage for sessions controller and service edge cases

### DIFF
--- a/apps/backend/tests/unit/sessions.controller.test.js
+++ b/apps/backend/tests/unit/sessions.controller.test.js
@@ -82,6 +82,25 @@ describe('sessions.controller', () => {
       assert.equal(next.mock.calls.length, 0);
     });
 
+    it('returns 400 when subject is missing', async () => {
+      const service = {
+        createSession: mock.fn(),
+        completeSession: mock.fn(),
+        listSessions: mock.fn(),
+      };
+      const { startSession } = createSessionsController(service);
+      const req = { body: { userId: 'user-1' } };
+      const res = createMockResponse();
+      const next = mock.fn();
+
+      await startSession(req, res, next);
+
+      assert.equal(res.statusCode, 400);
+      assert.deepEqual(res.body, { error: 'subject is required' });
+      assert.equal(service.createSession.mock.calls.length, 0);
+      assert.equal(next.mock.calls.length, 0);
+    });
+
     it('creates a session and returns 201', async () => {
       // Arrange
       const createdSession = { id: 'session-1' };
@@ -188,6 +207,25 @@ describe('sessions.controller', () => {
       assert.equal(res.statusCode, 404);
       assert.deepEqual(res.body, { error: 'Session not found' });
       assert.equal(service.completeSession.mock.calls.length, 1);
+      assert.equal(next.mock.calls.length, 0);
+    });
+
+    it('returns 400 when endedAt is missing', async () => {
+      const service = {
+        createSession: mock.fn(),
+        completeSession: mock.fn(),
+        listSessions: mock.fn(),
+      };
+      const { completeSession } = createSessionsController(service);
+      const req = { params: { id: 'session-1' }, body: {} };
+      const res = createMockResponse();
+      const next = mock.fn();
+
+      await completeSession(req, res, next);
+
+      assert.equal(res.statusCode, 400);
+      assert.deepEqual(res.body, { error: 'endedAt is required' });
+      assert.equal(service.completeSession.mock.calls.length, 0);
       assert.equal(next.mock.calls.length, 0);
     });
 

--- a/apps/backend/tests/unit/sessions.service.test.js
+++ b/apps/backend/tests/unit/sessions.service.test.js
@@ -1,0 +1,170 @@
+/**
+ * ────────────────────────────────────────────────────────────────────────────────
+ *  File: tests/unit/sessions.service.test.js
+ *  Group: Group 3 — COMP 4350: Software Engineering 2
+ *  Project: Studly
+ * ────────────────────────────────────────────────────────────────────────────────
+ *  Summary
+ *  -------
+ *  Unit tests for the Sessions service layer. These tests exercise the query
+ *  builder interactions with a mocked Supabase client to ensure:
+ *    • Correct table/column names are used
+ *    • Happy-path records are returned to callers
+ *    • Failures throw descriptive errors for controller middleware to handle
+ *
+ *  NOTE: We rely on Node's built-in test runner (`node:test`) and its mocking
+ *  utilities so no additional testing frameworks are required.
+ * ────────────────────────────────────────────────────────────────────────────────
+ */
+
+import assert from 'node:assert/strict';
+import { describe, it, mock } from 'node:test';
+
+import { createSessionsService } from '../../src/services/sessions.service.js';
+
+describe('sessions.service', () => {
+  describe('createSession', () => {
+    it('inserts into the sessions table and returns the created row', async () => {
+      const created = { id: 'session-1', subject: 'Math' };
+
+      const single = mock.fn(async () => ({ data: created, error: null }));
+      const select = mock.fn(() => ({ single }));
+      const insert = mock.fn(() => ({ select }));
+      const from = mock.fn(() => ({ insert }));
+      const client = { from };
+
+      const service = createSessionsService(client);
+      const result = await service.createSession({ subject: 'Math' });
+
+      assert.deepEqual(result, created);
+      assert.equal(from.mock.calls[0].arguments[0], 'sessions');
+      assert.deepEqual(insert.mock.calls[0].arguments[0], { subject: 'Math' });
+      assert.equal(single.mock.calls.length, 1);
+    });
+
+    it('throws a descriptive error when Supabase returns an error', async () => {
+      const single = mock.fn(async () => ({ data: null, error: { message: 'row violates constraint' } }));
+      const select = mock.fn(() => ({ single }));
+      const insert = mock.fn(() => ({ select }));
+      const from = mock.fn(() => ({ insert }));
+      const client = { from };
+
+      const service = createSessionsService(client);
+
+      await assert.rejects(
+        () => service.createSession({ subject: 'Physics' }),
+        /Failed to create session: row violates constraint/
+      );
+    });
+  });
+
+  describe('completeSession', () => {
+    it('updates the targeted session and returns the updated row', async () => {
+      const updated = { id: 'session-1', status: 'completed' };
+
+      const maybeSingle = mock.fn(async () => ({ data: updated, error: null }));
+      const select = mock.fn(() => ({ maybeSingle }));
+      const eq = mock.fn(() => ({ select }));
+      const update = mock.fn(() => ({ eq }));
+      const from = mock.fn(() => ({ update }));
+      const client = { from };
+
+      const service = createSessionsService(client);
+      const result = await service.completeSession('session-1', { status: 'completed' });
+
+      assert.deepEqual(result, updated);
+      assert.equal(from.mock.calls[0].arguments[0], 'sessions');
+      assert.deepEqual(update.mock.calls[0].arguments[0], { status: 'completed' });
+      assert.deepEqual(eq.mock.calls[0].arguments, ['id', 'session-1']);
+      assert.equal(maybeSingle.mock.calls.length, 1);
+    });
+
+    it('returns null when Supabase finds no matching session', async () => {
+      const maybeSingle = mock.fn(async () => ({ data: null, error: null }));
+      const select = mock.fn(() => ({ maybeSingle }));
+      const eq = mock.fn(() => ({ select }));
+      const update = mock.fn(() => ({ eq }));
+      const from = mock.fn(() => ({ update }));
+      const client = { from };
+
+      const service = createSessionsService(client);
+      const result = await service.completeSession('missing-id', { status: 'completed' });
+
+      assert.equal(result, null);
+    });
+
+    it('throws a descriptive error when Supabase update fails', async () => {
+      const maybeSingle = mock.fn(async () => ({ data: null, error: { message: 'permission denied' } }));
+      const select = mock.fn(() => ({ maybeSingle }));
+      const eq = mock.fn(() => ({ select }));
+      const update = mock.fn(() => ({ eq }));
+      const from = mock.fn(() => ({ update }));
+      const client = { from };
+
+      const service = createSessionsService(client);
+
+      await assert.rejects(
+        () => service.completeSession('session-1', { status: 'completed' }),
+        /Failed to complete session: permission denied/
+      );
+    });
+  });
+
+  describe('listSessions', () => {
+    it('applies filters and orders results by started_at descending', async () => {
+      const expected = [{ id: 'session-1' }];
+
+      const order = mock.fn(async () => ({ data: expected, error: null }));
+      const builder = {
+        select: mock.fn(() => builder),
+        eq: mock.fn(() => builder),
+        order,
+      };
+      const from = mock.fn(() => builder);
+      const client = { from };
+
+      const service = createSessionsService(client);
+      const result = await service.listSessions({ userId: 'user-1', subject: 'Math' });
+
+      assert.deepEqual(result, expected);
+      assert.equal(from.mock.calls[0].arguments[0], 'sessions');
+      assert.deepEqual(builder.select.mock.calls[0].arguments, ['*']);
+      assert.deepEqual(builder.eq.mock.calls[0].arguments, ['user_id', 'user-1']);
+      assert.deepEqual(builder.eq.mock.calls[1].arguments, ['subject', 'Math']);
+      assert.equal(order.mock.calls[0].arguments[0], 'started_at');
+      assert.deepEqual(order.mock.calls[0].arguments[1], { ascending: false });
+    });
+
+    it('returns an empty array when Supabase yields no rows', async () => {
+      const order = mock.fn(async () => ({ data: null, error: null }));
+      const builder = {
+        select: mock.fn(() => builder),
+        eq: mock.fn(() => builder),
+        order,
+      };
+      const from = mock.fn(() => builder);
+      const client = { from };
+
+      const service = createSessionsService(client);
+      const result = await service.listSessions();
+
+      assert.deepEqual(result, []);
+    });
+
+    it('throws a descriptive error when the query fails', async () => {
+      const order = mock.fn(async () => ({ data: null, error: { message: 'timeout' } }));
+      const builder = {
+        select: mock.fn(() => builder),
+        eq: mock.fn(() => builder),
+        order,
+      };
+      const from = mock.fn(() => builder);
+      const client = { from };
+
+      const service = createSessionsService(client);
+
+      await assert.rejects(() => service.listSessions(), /Failed to list sessions: timeout/);
+    });
+  });
+});
+


### PR DESCRIPTION
## Summary
- add controller tests for missing session subject and endedAt validation paths
- add unit coverage for the sessions service Supabase interactions and error handling

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68eb09852198832d851f9ef5a67aa128