### PR TITLE
Align sessions API with frontend contract

### DIFF
--- a/apps/backend/src/routes/v1/sessions.routes.js
+++ b/apps/backend/src/routes/v1/sessions.routes.js
@@ -3,9 +3,10 @@
  *  File: src/routes/v1/sessions.routes.js
  *  Group: Group 3 — COMP 4350: Software Engineering 2
  *  Project: Studly
- *  Author: Shiv Bhagat
- *  Comments: Curated by GPT (Large Language Model)
- *  Last-Updated: 2025-10-15
+ *  Author: Hamed Esmaeilzadeh (team member)
+ *  Assisted-by: ChatGPT (GPT-5 Thinking) for comments, documentation, debugging,
+ *               and partial code contributions
+ *  Last-Updated: 2025-10-16
  * ────────────────────────────────────────────────────────────────────────────────
  *  Summary
  *  -------
@@ -16,8 +17,9 @@
  *  Features
  *  --------
  *  • POST /sessions → start a new session.
- *  • PATCH /sessions/:id/complete → mark a session as complete.
- *  • GET /sessions → list sessions with optional query filters.
+ *  • PATCH /sessions/:sessionId → mark a session as complete.
+ *  • GET /sessions → list sessions with optional query filters (userId, status, limit).
+ *  • GET /sessions/summary → provide aggregated study metrics.
  *
  *  Design Principles
  *  -----------------
@@ -40,12 +42,14 @@ import {
   startSession,
   completeSession,
   listSessions,
+  getSessionsSummary,
 } from '../../controllers/sessions.controller.js';
 
 const router = Router();
 
 router.post('/', startSession);
-router.patch('/:id/complete', completeSession);
+router.patch('/:sessionId', completeSession);
 router.get('/', listSessions);
+router.get('/summary', getSessionsSummary);
 
 export default router;

--- a/apps/backend/tests/integration/sessions.test.js
+++ b/apps/backend/tests/integration/sessions.test.js
@@ -1,0 +1,454 @@
+/**
+ * ────────────────────────────────────────────────────────────────────────────────
+ *  File: tests/integration/sessions.test.js
+ *  Group: Group 3 — COMP 4350: Software Engineering 2
+ *  Project: Studly
+ *  Author: Hamed Esmaeilzadeh (team member)
+ *  Assisted-by: ChatGPT (GPT-5 Thinking) for comments, documentation, debugging,
+ *               and partial code contributions
+ *  Last-Updated: 2025-10-16
+ * ────────────────────────────────────────────────────────────────────────────────
+ *  Summary
+ *  -------
+ *  Integration coverage for the sessions API router. The suite boots the Express
+ *  application, overrides the Supabase client with an in-memory stub, and drives
+ *  HTTP requests end-to-end using the built-in fetch implementation.
+ *
+ *  Features
+ *  --------
+ *  • Covers start, complete, list, and summary flows.
+ *  • Exercises validation failures alongside Supabase error propagation.
+ *  • Ensures milliseconds ↔ minutes conversions survive the HTTP boundary.
+ *
+ *  Design Principles
+ *  -----------------
+ *  • Reset stub state before each test for isolation.
+ *  • Keep the mock minimal yet representative of real Supabase chaining.
+ *  • Prefer descriptive test names for quick diagnosis.
+ *
+ *  TODOs
+ *  -----
+ *  • [AUTHZ] Add authenticated user context once auth middleware is wired.
+ *  • [LOAD] Expand coverage for pagination edge cases (e.g., deep offsets).
+ *
+ *  @module tests/integration/sessions
+ * ────────────────────────────────────────────────────────────────────────────────
+ */
+
+import test, { beforeEach, afterEach } from 'node:test';
+import assert from 'node:assert/strict';
+
+import supabase from '../../src/config/supabase.js';
+
+process.env.NODE_ENV = 'test';
+const { default: app } = await import('../../src/index.js');
+
+const originalFrom = supabase.from;
+
+let sessionCounter = 1;
+const sessionStore = [];
+const behaviors = {
+  insertError: null,
+  updateError: null,
+  listError: null,
+  summaryError: null,
+};
+
+const resetBehaviors = () => {
+  behaviors.insertError = null;
+  behaviors.updateError = null;
+  behaviors.listError = null;
+  behaviors.summaryError = null;
+};
+
+const resetStore = () => {
+  sessionStore.length = 0;
+  sessionCounter = 1;
+};
+
+const makeRow = (payload) => {
+  const now = new Date().toISOString();
+  const row = {
+    id: `session-${sessionCounter++}`,
+    created_at: now,
+    updated_at: now,
+    ended_at: null,
+    duration_minutes: null,
+    ...payload,
+  };
+  sessionStore.push(row);
+  return row;
+};
+
+const applyFilters = (rows, filters) => {
+  let result = [...rows];
+
+  for (const { column, value } of filters.eq) {
+    result = result.filter((row) => row[column] === value);
+  }
+
+  for (const { column, value } of filters.gte) {
+    result = result.filter((row) => {
+      if (!row[column]) return false;
+      return row[column] >= value;
+    });
+  }
+
+  for (const { column, value } of filters.lte) {
+    result = result.filter((row) => {
+      if (!row[column]) return false;
+      return row[column] <= value;
+    });
+  }
+
+  if (filters.order) {
+    const { column, options } = filters.order;
+    result.sort((a, b) => {
+      const left = a[column];
+      const right = b[column];
+      if (left === right) return 0;
+      if (left === null) return options?.nullsFirst ? -1 : 1;
+      if (right === null) return options?.nullsFirst ? 1 : -1;
+      if (left < right) return options?.ascending ? -1 : 1;
+      return options?.ascending ? 1 : -1;
+    });
+  }
+
+  if (typeof filters.limit === 'number') {
+    result = result.slice(0, filters.limit);
+  }
+
+  return result;
+};
+
+const selectColumns = (rows, columns) => {
+  if (columns === '*') {
+    return rows.map((row) => ({ ...row }));
+  }
+
+  const fields = columns.split(',').map((part) => part.trim());
+  return rows.map((row) => {
+    return fields.reduce((acc, field) => {
+      acc[field] = row[field] ?? null;
+      return acc;
+    }, {});
+  });
+};
+
+const createSelectBuilder = (columns) => {
+  const filters = {
+    eq: [],
+    gte: [],
+    lte: [],
+    limit: undefined,
+    order: null,
+  };
+
+  const resolve = () => {
+    if (columns === '*' && behaviors.listError) {
+      return { data: null, error: { message: behaviors.listError } };
+    }
+    if (columns !== '*' && behaviors.summaryError) {
+      return { data: null, error: { message: behaviors.summaryError } };
+    }
+
+    const rows = applyFilters(sessionStore, filters);
+    return { data: selectColumns(rows, columns), error: null };
+  };
+
+  const builder = {
+    eq(column, value) {
+      filters.eq.push({ column, value });
+      return builder;
+    },
+    gte(column, value) {
+      filters.gte.push({ column, value });
+      return builder;
+    },
+    lte(column, value) {
+      filters.lte.push({ column, value });
+      return builder;
+    },
+    limit(value) {
+      filters.limit = value;
+      return builder;
+    },
+    order(column, options) {
+      filters.order = { column, options };
+      const result = resolve();
+      return Promise.resolve(result);
+    },
+    then(onFulfilled, onRejected) {
+      try {
+        const result = resolve();
+        return Promise.resolve(onFulfilled ? onFulfilled(result) : result);
+      } catch (error) {
+        return onRejected ? Promise.resolve(onRejected(error)) : Promise.reject(error);
+      }
+    },
+  };
+
+  return builder;
+};
+
+const installSupabaseStub = () => {
+  supabase.from = (table) => {
+    if (table !== 'sessions') {
+      throw new Error(`Unexpected table requested: ${table}`);
+    }
+
+    return {
+      insert(values) {
+        return {
+          select() {
+            return {
+              async single() {
+                if (behaviors.insertError) {
+                  return { data: null, error: { message: behaviors.insertError } };
+                }
+                const row = makeRow(values);
+                return { data: row, error: null };
+              },
+            };
+          },
+        };
+      },
+      update(updates) {
+        return {
+          eq(column, value) {
+            return {
+              select() {
+                return {
+                  async maybeSingle() {
+                    if (behaviors.updateError) {
+                      return { data: null, error: { message: behaviors.updateError } };
+                    }
+
+                    const session = sessionStore.find((row) => row[column] === value);
+                    if (!session) return { data: null, error: null };
+
+                    Object.assign(session, updates, { updated_at: new Date().toISOString() });
+                    return { data: { ...session }, error: null };
+                  },
+                };
+              },
+            };
+          },
+        };
+      },
+      select(columns = '*') {
+        return createSelectBuilder(columns);
+      },
+    };
+  };
+};
+
+const restoreSupabase = () => {
+  supabase.from = originalFrom;
+};
+
+const startServer = () =>
+  new Promise((resolve) => {
+    const server = app.listen(0, () => {
+      const address = server.address();
+      resolve({ server, url: `http://127.0.0.1:${address.port}` });
+    });
+  });
+
+const stopServer = (server) =>
+  new Promise((resolve, reject) => {
+    server.close((err) => (err ? reject(err) : resolve()));
+  });
+
+const request = async (method, path, body) => {
+  const { server, url } = await startServer();
+
+  try {
+    const response = await fetch(`${url}${path}`, {
+      method,
+      headers: body ? { 'Content-Type': 'application/json' } : undefined,
+      body: body ? JSON.stringify(body) : undefined,
+    });
+
+    const text = await response.text();
+    let parsed;
+    try {
+      parsed = text ? JSON.parse(text) : undefined;
+    } catch {
+      parsed = text;
+    }
+
+    return { status: response.status, body: parsed };
+  } finally {
+    await stopServer(server);
+  }
+};
+
+beforeEach(() => {
+  resetStore();
+  resetBehaviors();
+  installSupabaseStub();
+});
+
+afterEach(() => {
+  restoreSupabase();
+  resetStore();
+  resetBehaviors();
+});
+
+test('POST /api/v1/sessions starts a session and returns camelCase fields', async () => {
+  const response = await request('POST', '/api/v1/sessions', {
+    userId: 'user-1',
+    subject: 'Math',
+    startTimestamp: '2024-01-01T00:00:00.000Z',
+    targetDurationMillis: 1_200_000,
+  });
+
+  assert.equal(response.status, 201);
+  assert.equal(response.body.session.userId, 'user-1');
+  assert.equal(response.body.session.subject, 'Math');
+  assert.equal(response.body.session.targetDurationMillis, 1_200_000);
+  assert.equal(response.body.session.status, 'in_progress');
+});
+
+test('POST /api/v1/sessions returns 400 for missing subject', async () => {
+  const response = await request('POST', '/api/v1/sessions', {
+    userId: 'user-1',
+  });
+
+  assert.equal(response.status, 400);
+  assert.equal(response.body.error, 'subject is required');
+});
+
+test('POST /api/v1/sessions surfaces Supabase errors', async () => {
+  behaviors.insertError = 'insert blew up';
+
+  const response = await request('POST', '/api/v1/sessions', {
+    userId: 'user-1',
+    subject: 'Biology',
+  });
+
+  assert.equal(response.status, 500);
+  assert.match(String(response.body), /Error: Failed to create session: insert blew up/);
+});
+
+test('PATCH /api/v1/sessions/:id completes a session and returns updated payload', async () => {
+  const start = await request('POST', '/api/v1/sessions', {
+    userId: 'user-1',
+    subject: 'Chemistry',
+  });
+
+  const sessionId = start.body.session.id;
+
+  const complete = await request('PATCH', `/api/v1/sessions/${sessionId}`, {
+    endStudyTimestamp: '2024-01-01T00:30:00.000Z',
+    sessionLengthMillis: 1_800_000,
+    notes: 'Great focus',
+  });
+
+  assert.equal(complete.status, 200);
+  assert.equal(complete.body.session.status, 'completed');
+  assert.equal(complete.body.session.endStudyTimestamp, '2024-01-01T00:30:00.000Z');
+  assert.equal(complete.body.session.sessionLength, 1_800_000);
+  assert.equal(complete.body.session.notes, 'Great focus');
+});
+
+test('PATCH /api/v1/sessions/:id returns 404 when the session is missing', async () => {
+  const response = await request('PATCH', '/api/v1/sessions/session-missing', {
+    endStudyTimestamp: '2024-01-01T00:10:00.000Z',
+  });
+
+  assert.equal(response.status, 404);
+  assert.equal(response.body.error, 'Session not found');
+});
+
+test('PATCH /api/v1/sessions/:id propagates Supabase failures', async () => {
+  behaviors.updateError = 'update exploded';
+
+  const start = await request('POST', '/api/v1/sessions', {
+    userId: 'user-1',
+    subject: 'Physics',
+  });
+
+  const sessionId = start.body.session.id;
+  const response = await request('PATCH', `/api/v1/sessions/${sessionId}`, {
+    endStudyTimestamp: '2024-01-01T00:10:00.000Z',
+  });
+
+  assert.equal(response.status, 500);
+  assert.match(String(response.body), /Error: Failed to complete session: update exploded/);
+});
+
+test('GET /api/v1/sessions lists sessions ordered by completion time', async () => {
+  const first = await request('POST', '/api/v1/sessions', {
+    userId: 'user-1',
+    subject: 'History',
+    targetDurationMillis: 600_000,
+  });
+  const second = await request('POST', '/api/v1/sessions', {
+    userId: 'user-1',
+    subject: 'History',
+  });
+
+  await request('PATCH', `/api/v1/sessions/${first.body.session.id}`, {
+    endStudyTimestamp: '2024-01-01T00:20:00.000Z',
+    sessionLengthMillis: 1_200_000,
+  });
+  await request('PATCH', `/api/v1/sessions/${second.body.session.id}`, {
+    endStudyTimestamp: '2024-01-01T00:40:00.000Z',
+    sessionLengthMillis: 1_800_000,
+  });
+
+  const response = await request(
+    'GET',
+    '/api/v1/sessions?userId=user-1&subject=History&status=completed&limit=10',
+  );
+
+  assert.equal(response.status, 200);
+  assert.equal(response.body.sessions.length, 2);
+  assert.equal(response.body.sessions[0].endStudyTimestamp, '2024-01-01T00:40:00.000Z');
+  assert.equal(response.body.sessions[1].endStudyTimestamp, '2024-01-01T00:20:00.000Z');
+});
+
+test('GET /api/v1/sessions enforces numeric limit', async () => {
+  const response = await request('GET', '/api/v1/sessions?userId=user-1&limit=zero');
+
+  assert.equal(response.status, 400);
+  assert.equal(response.body.error, 'limit must be a positive integer');
+});
+
+test('GET /api/v1/sessions surfaces Supabase list errors', async () => {
+  behaviors.listError = 'list exploded';
+  const response = await request('GET', '/api/v1/sessions?userId=user-1');
+
+  assert.equal(response.status, 500);
+  assert.match(String(response.body), /Error: Failed to list sessions: list exploded/);
+});
+
+test('GET /api/v1/sessions/summary returns aggregate metrics in milliseconds', async () => {
+  const start = await request('POST', '/api/v1/sessions', {
+    userId: 'user-1',
+    subject: 'Art',
+  });
+  await request('PATCH', `/api/v1/sessions/${start.body.session.id}`, {
+    endStudyTimestamp: '2024-01-01T01:00:00.000Z',
+    sessionLengthMillis: 3_600_000,
+  });
+
+  const response = await request(
+    'GET',
+    '/api/v1/sessions/summary?userId=user-1&from=2024-01-01&to=2024-01-02',
+  );
+
+  assert.equal(response.status, 200);
+  assert.equal(response.body.totalTimeStudied, 3_600_000);
+  assert.equal(response.body.timesStudied, 1);
+});
+
+test('GET /api/v1/sessions/summary surfaces Supabase summary errors', async () => {
+  behaviors.summaryError = 'summary exploded';
+  const response = await request('GET', '/api/v1/sessions/summary?userId=user-1');
+
+  assert.equal(response.status, 500);
+  assert.match(String(response.body), /Error: Failed to summarize sessions: summary exploded/);
+});

--- a/apps/backend/tests/unit/sessions.service.test.js
+++ b/apps/backend/tests/unit/sessions.service.test.js
@@ -3,14 +3,19 @@
  *  File: tests/unit/sessions.service.test.js
  *  Group: Group 3 — COMP 4350: Software Engineering 2
  *  Project: Studly
+ *  Author: Hamed Esmaeilzadeh (team member)
+ *  Assisted-by: ChatGPT (GPT-5 Thinking) for comments, documentation, debugging,
+ *               and partial code contributions
+ *  Last-Updated: 2025-10-16
  * ────────────────────────────────────────────────────────────────────────────────
  *  Summary
  *  -------
  *  Unit tests for the Sessions service layer. These tests exercise the query
  *  builder interactions with a mocked Supabase client to ensure:
  *    • Correct table/column names are used
- *    • Happy-path records are returned to callers
+ *    • Happy-path records are returned to callers with camelCase conversions
  *    • Failures throw descriptive errors for controller middleware to handle
+ *    • Aggregation helpers compute dashboard metrics in milliseconds
  *
  *  NOTE: We rely on Node's built-in test runner (`node:test`) and its mocking
  *  utilities so no additional testing frameworks are required.
@@ -24,8 +29,17 @@ import { createSessionsService } from '../../src/services/sessions.service.js';
 
 describe('sessions.service', () => {
   describe('createSession', () => {
-    it('inserts into the sessions table and returns the created row', async () => {
-      const created = { id: 'session-1', subject: 'Math' };
+    it('inserts into the sessions table and returns a camelCase session', async () => {
+      const created = {
+        id: 'session-1',
+        user_id: 'user-1',
+        subject: 'Math',
+        status: 'in_progress',
+        started_at: '2024-01-01T00:00:00.000Z',
+        target_duration_minutes: 1.5,
+        duration_minutes: null,
+        ended_at: null,
+      };
 
       const single = mock.fn(async () => ({ data: created, error: null }));
       const select = mock.fn(() => ({ single }));
@@ -36,10 +50,11 @@ describe('sessions.service', () => {
       const service = createSessionsService(client);
       const result = await service.createSession({ subject: 'Math' });
 
-      assert.deepEqual(result, created);
       assert.equal(from.mock.calls[0].arguments[0], 'sessions');
       assert.deepEqual(insert.mock.calls[0].arguments[0], { subject: 'Math' });
-      assert.equal(single.mock.calls.length, 1);
+      assert.equal(result.id, 'session-1');
+      assert.equal(result.targetDurationMillis, 90_000);
+      assert.equal(result.sessionLength, null);
     });
 
     it('throws a descriptive error when Supabase returns an error', async () => {
@@ -53,14 +68,21 @@ describe('sessions.service', () => {
 
       await assert.rejects(
         () => service.createSession({ subject: 'Physics' }),
-        /Failed to create session: row violates constraint/
+        /Failed to create session: row violates constraint/,
       );
     });
   });
 
   describe('completeSession', () => {
-    it('updates the targeted session and returns the updated row', async () => {
-      const updated = { id: 'session-1', status: 'completed' };
+    it('updates the targeted session and returns camelCase data', async () => {
+      const updated = {
+        id: 'session-1',
+        user_id: 'user-1',
+        status: 'completed',
+        ended_at: '2024-01-01T00:10:00.000Z',
+        duration_minutes: 10,
+        target_duration_minutes: 30,
+      };
 
       const maybeSingle = mock.fn(async () => ({ data: updated, error: null }));
       const select = mock.fn(() => ({ maybeSingle }));
@@ -72,11 +94,10 @@ describe('sessions.service', () => {
       const service = createSessionsService(client);
       const result = await service.completeSession('session-1', { status: 'completed' });
 
-      assert.deepEqual(result, updated);
-      assert.equal(from.mock.calls[0].arguments[0], 'sessions');
       assert.deepEqual(update.mock.calls[0].arguments[0], { status: 'completed' });
       assert.deepEqual(eq.mock.calls[0].arguments, ['id', 'session-1']);
-      assert.equal(maybeSingle.mock.calls.length, 1);
+      assert.equal(result.sessionLength, 600_000);
+      assert.equal(result.targetDurationMillis, 1_800_000);
     });
 
     it('returns null when Supabase finds no matching session', async () => {
@@ -105,34 +126,59 @@ describe('sessions.service', () => {
 
       await assert.rejects(
         () => service.completeSession('session-1', { status: 'completed' }),
-        /Failed to complete session: permission denied/
+        /Failed to complete session: permission denied/,
       );
     });
   });
 
   describe('listSessions', () => {
-    it('applies filters and orders results by started_at descending', async () => {
-      const expected = [{ id: 'session-1' }];
+    it('applies filters, ordering, and maps rows to camelCase', async () => {
+      const rows = [
+        {
+          id: 'session-1',
+          user_id: 'user-1',
+          subject: 'Math',
+          status: 'completed',
+          ended_at: '2024-01-02T00:00:00.000Z',
+          duration_minutes: 10,
+          target_duration_minutes: 30,
+          notes: 'Great focus',
+        },
+      ];
 
-      const order = mock.fn(async () => ({ data: expected, error: null }));
+      const order = mock.fn(async () => ({ data: rows, error: null }));
       const builder = {
         select: mock.fn(() => builder),
         eq: mock.fn(() => builder),
+        gte: mock.fn(() => builder),
+        lte: mock.fn(() => builder),
+        limit: mock.fn(() => builder),
         order,
       };
       const from = mock.fn(() => builder);
       const client = { from };
 
       const service = createSessionsService(client);
-      const result = await service.listSessions({ userId: 'user-1', subject: 'Math' });
+      const result = await service.listSessions({
+        userId: 'user-1',
+        subject: 'Math',
+        status: 'completed',
+        endedAfter: '2024-01-01T00:00:00.000Z',
+        endedBefore: '2024-01-03T00:00:00.000Z',
+        limit: 5,
+      });
 
-      assert.deepEqual(result, expected);
       assert.equal(from.mock.calls[0].arguments[0], 'sessions');
-      assert.deepEqual(builder.select.mock.calls[0].arguments, ['*']);
       assert.deepEqual(builder.eq.mock.calls[0].arguments, ['user_id', 'user-1']);
       assert.deepEqual(builder.eq.mock.calls[1].arguments, ['subject', 'Math']);
-      assert.equal(order.mock.calls[0].arguments[0], 'started_at');
-      assert.deepEqual(order.mock.calls[0].arguments[1], { ascending: false });
+      assert.deepEqual(builder.eq.mock.calls[2].arguments, ['status', 'completed']);
+      assert.deepEqual(builder.gte.mock.calls[0].arguments, ['ended_at', '2024-01-01T00:00:00.000Z']);
+      assert.deepEqual(builder.lte.mock.calls[0].arguments, ['ended_at', '2024-01-03T00:00:00.000Z']);
+      assert.deepEqual(builder.limit.mock.calls[0].arguments, [5]);
+      assert.deepEqual(order.mock.calls[0].arguments, ['ended_at', { ascending: false, nullsFirst: false }]);
+      assert.equal(result[0].sessionLength, 600_000);
+      assert.equal(result[0].targetDurationMillis, 1_800_000);
+      assert.equal(result[0].notes, 'Great focus');
     });
 
     it('returns an empty array when Supabase yields no rows', async () => {
@@ -140,6 +186,9 @@ describe('sessions.service', () => {
       const builder = {
         select: mock.fn(() => builder),
         eq: mock.fn(() => builder),
+        gte: mock.fn(() => builder),
+        lte: mock.fn(() => builder),
+        limit: mock.fn(() => builder),
         order,
       };
       const from = mock.fn(() => builder);
@@ -156,6 +205,9 @@ describe('sessions.service', () => {
       const builder = {
         select: mock.fn(() => builder),
         eq: mock.fn(() => builder),
+        gte: mock.fn(() => builder),
+        lte: mock.fn(() => builder),
+        limit: mock.fn(() => builder),
         order,
       };
       const from = mock.fn(() => builder);
@@ -164,6 +216,69 @@ describe('sessions.service', () => {
       const service = createSessionsService(client);
 
       await assert.rejects(() => service.listSessions(), /Failed to list sessions: timeout/);
+    });
+  });
+
+  describe('summarizeSessionsByDate', () => {
+    it('aggregates total duration in milliseconds and counts sessions', async () => {
+      const rows = [
+        { duration_minutes: 10, status: 'completed', ended_at: '2024-01-01T01:00:00.000Z' },
+        { duration_minutes: 5.5, status: 'completed', ended_at: '2024-01-01T02:00:00.000Z' },
+      ];
+
+      const builder = {
+        select: mock.fn(() => builder),
+        eq: mock.fn(() => builder),
+        gte: mock.fn(() => builder),
+        lte: mock.fn(() => ({ data: rows, error: null })),
+      };
+      const from = mock.fn(() => builder);
+      const client = { from };
+
+      const service = createSessionsService(client);
+
+      const summary = await service.summarizeSessionsByDate({
+        userId: 'user-1',
+        from: '2024-01-01',
+        to: '2024-01-02',
+        status: 'completed',
+      });
+
+      assert.equal(from.mock.calls[0].arguments[0], 'sessions');
+      assert.deepEqual(builder.select.mock.calls[0].arguments, ['duration_minutes, ended_at, status']);
+      assert.deepEqual(builder.eq.mock.calls[0].arguments, ['user_id', 'user-1']);
+      assert.deepEqual(builder.eq.mock.calls[1].arguments, ['status', 'completed']);
+      assert.deepEqual(builder.gte.mock.calls[0].arguments, ['ended_at', '2024-01-01']);
+      assert.deepEqual(builder.lte.mock.calls[0].arguments, ['ended_at', '2024-01-02']);
+      assert.equal(summary.totalTimeStudied, 930_000);
+      assert.equal(summary.timesStudied, 2);
+    });
+
+    it('throws a descriptive error when the summary query fails', async () => {
+      const result = { data: null, error: { message: 'boom' } };
+      const builder = {
+        select: mock.fn(() => builder),
+        eq: mock.fn(() => builder),
+        gte: mock.fn(() => builder),
+        lte: mock.fn(() => builder),
+        then(onFulfilled, onRejected) {
+          try {
+            const value = onFulfilled ? onFulfilled(result) : result;
+            return Promise.resolve(value);
+          } catch (error) {
+            return onRejected ? Promise.resolve(onRejected(error)) : Promise.reject(error);
+          }
+        },
+      };
+      const from = mock.fn(() => builder);
+      const client = { from };
+
+      const service = createSessionsService(client);
+
+      await assert.rejects(
+        () => service.summarizeSessionsByDate({ userId: 'user-1' }),
+        /Failed to summarize sessions: boom/,
+      );
     });
   });
 });


### PR DESCRIPTION
## Summary
- convert the sessions controller to accept millisecond payloads, add pagination parsing, and expose a summary endpoint for dashboard consumption
- enhance the sessions service with camelCase mapping, richer query filters, and a summarizeSessionsByDate helper to back the new route
- update routing metadata and expand the sessions unit test suites alongside a new integration suite covering happy paths and Supabase failures

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ef10eb3144832db5009f5000a66341