### PR TITLE
chore(lint): standardize ESLint + Biome configs; add Windows lint script

### DIFF
--- a/apps/backend/.eslintrc.cjs
+++ b/apps/backend/.eslintrc.cjs
@@ -1,0 +1,16 @@
+module.exports = {
+  root: true,
+  env: {
+    node: true,
+    es2022: true
+  },
+  extends: [
+    'eslint:recommended'
+  ],
+  parserOptions: {
+    ecmaVersion: 'latest',
+    sourceType: 'module'
+  },
+  ignorePatterns: ['node_modules/', 'dist/', 'coverage/']
+};
+

--- a/apps/backend/biome.json
+++ b/apps/backend/biome.json
@@ -1,0 +1,9 @@
+{
+  "linter": {
+    "enabled": true,
+    "rules": {
+      "recommended": true
+    }
+  }
+}
+

--- a/apps/frontend/.eslintrc.cjs
+++ b/apps/frontend/.eslintrc.cjs
@@ -1,0 +1,35 @@
+/* eslint-disable no-undef */
+/* eslint-env node */
+module.exports = {
+  root: true,
+  env: {
+    browser: true,
+    es2022: true
+  },
+  parser: '@typescript-eslint/parser',
+  parserOptions: {
+    ecmaVersion: 'latest',
+    sourceType: 'module'
+  },
+  plugins: ['@typescript-eslint', 'react', 'react-hooks', 'jsx-a11y', 'react-refresh'],
+  extends: [
+    'eslint:recommended',
+    'plugin:@typescript-eslint/recommended',
+    'plugin:react/recommended',
+    'plugin:jsx-a11y/recommended'
+  ],
+  settings: {
+    react: {
+      version: 'detect'
+    }
+  },
+  rules: {
+    'react/react-in-jsx-scope': 'off',
+    'react/prop-types': 'off',
+    'react-refresh/only-export-components': 'warn',
+    '@typescript-eslint/no-explicit-any': 'off',
+    'react-hooks/rules-of-hooks': 'error',
+    'react-hooks/exhaustive-deps': 'warn'
+  },
+  ignorePatterns: ['dist/', 'node_modules/', 'coverage/']
+};

--- a/apps/frontend/package.json
+++ b/apps/frontend/package.json
@@ -16,6 +16,7 @@
     "test:e2e:ui": "start-server-and-test 'npm run start' http://localhost:5173 'npx cypress open --e2e'",
     "lint": "ESLINT_USE_FLAT_CONFIG=false eslint .",
     "lint:fix": "npm run lint -- --fix",
+    "lint:win": "eslint .",
     "format": "biome format --write src tests",
     "biome:check": "biome check --linter-enabled=true --formatter-enabled=false --organize-imports-enabled=false src cypress/e2e/ cypress/constants cypress/support"
   },


### PR DESCRIPTION
## Title

chore(lint): standardize ESLint + Biome configs; add Windows lint script

---

## Summary

Standardizes linting configurations across backend and frontend and adds a Windows-friendly lint script. CI remains unchanged and local checks pass.

---

## Changes

### Backend

* Added `apps/backend/biome.json` (recommended rules)
* Added `apps/backend/.eslintrc.cjs` (extends `eslint:recommended`)

### Frontend

* Added `apps/frontend/.eslintrc.cjs` (plugin recommendations)
* Preserved Biome recommended rules
* Added `lint:win` script in `apps/frontend/package.json`

### Editor / Config

* Config files annotated to avoid false positives when linting configs themselves

### CI

* Unchanged
* ESLint and Biome checks pass locally
