### PR TITLE
Fix Railway build by restoring backend Dockerfile; add separate mem Dockerfile for local stack

### DIFF
--- a/apps/backend/Dockerfile
+++ b/apps/backend/Dockerfile
@@ -1,21 +1,22 @@
-# apps/backend/Dockerfile (repo-root context expected)
-FROM node:20-alpine AS base
-WORKDIR /app
-ENV NODE_ENV=production
-ENV PORT=3000
-# Enable in-memory mock by default for self-contained images
-ENV STUDLY_USE_MOCK=1
+# apps/backend/Dockerfile
+# Use a small official node image (change tag if you need Node 22)
+FROM node:20-alpine
 
-# Install production deps for backend only
-COPY apps/backend/package*.json ./
+# Create app dir
+WORKDIR /app
+
+# Install build deps first (cacheable)
+COPY package*.json ./
+
+# Use a temporary cache location to avoid CI cache-lock issues
 RUN npm ci --omit=dev --cache /tmp/.npm-cache
 
-# Copy backend source
-COPY apps/backend/src ./src
+# Copy source
+COPY . .
 
-# Bundle mock and schema into predictable absolute paths
-COPY infra/docker/mock /infra/docker/mock
-COPY infra/docker/db/init /infra/docker/db/init
-
+# Expose port (should match PORT env in Railway)
 EXPOSE 3000
+
+# Run the app
+ENV NODE_ENV=production
 CMD ["node", "src/index.js"]

--- a/infra/docker/backend.mem.Dockerfile
+++ b/infra/docker/backend.mem.Dockerfile
@@ -1,0 +1,23 @@
+# infra/docker/backend.mem.Dockerfile
+# Self-contained backend image with in-memory mock and schema bundled
+FROM node:20-alpine AS base
+WORKDIR /app
+ENV NODE_ENV=production
+ENV PORT=3000
+# Enable in-memory mock by default for self-contained images
+ENV STUDLY_USE_MOCK=1
+
+# Install production deps for backend only (context is repo root)
+COPY apps/backend/package*.json ./
+RUN npm ci --omit=dev --cache /tmp/.npm-cache
+
+# Copy backend source
+COPY apps/backend/src ./src
+
+# Bundle mock and schema into predictable absolute paths
+COPY infra/docker/mock /infra/docker/mock
+COPY infra/docker/db/init /infra/docker/db/init
+
+EXPOSE 3000
+CMD ["node", "src/index.js"]
+

--- a/infra/docker/compose.mem.yml
+++ b/infra/docker/compose.mem.yml
@@ -3,11 +3,10 @@ services:
   backend:
     build:
       context: ../../
-      dockerfile: apps/backend/Dockerfile
+      dockerfile: infra/docker/backend.mem.Dockerfile
     container_name: studly_backend
     environment:
       PORT: 3000
-      STUDLY_USE_MOCK: "1"
       INTERNAL_API_TOKEN: studly-local-token
     ports:
       - "3000:3000"


### PR DESCRIPTION
## Summary

This PR fixes Railway deployment failures by restoring the original backend Dockerfile structure and adds a dedicated Dockerfile for the self-contained mock (in-memory) mode used in the local stack.

---

## What Changed

### 1. Backend Dockerfile for Railway

* Restored `apps/backend/Dockerfile` to a context-relative layout compatible with Railway's auto-detection.
* Uses:

  ```dockerfile
  COPY . .
  ```

  allowing Railway to correctly access `/apps/backend/src` during the build.

### 2. New Dockerfile for Mock Mode (Local Stack)

* Added `infra/docker/backend.mem.Dockerfile`.
* Includes mock schema and client from:

  * `infra/docker/mock/`
  * `infra/docker/db/init/`
* Used only for local in-memory stack; not used in production or Railway.

### 3. Compose Update

* Updated `infra/docker/compose.mem.yml` to:

  * Build backend using repository root as context.
  * Use `infra/docker/backend.mem.Dockerfile` instead of the default backend Dockerfile.
