### PR TITLE
docs: add Docker port binding examples, Quickstart link, and Docker Hub references; mention Gordon LLM

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,28 @@ COMP 4350 - Software Engineering 2 - Group Project
 
 [Running Biome on the Frontend](./docs/running-biome-on-the-frontend.md)
 
+[Docker Quickstart](./infra/docker/QUICKSTART.md)
+
 ## Worksheet Links
 [Sprint 0](sprint0.md)
 
 [Sprint 1](./worksheets/sprint1/sprint1worksheet.md)
+
+
+
+## Containrization Ducker Hub
+For convenience, pre-built frontend and backend images have been pushed to Docker Hub. You can pull and run these images directly without building locally.
+
+- Backend image: https://hub.docker.com/r/hamed1379/studly-backend
+- Frontend image: https://hub.docker.com/r/hamed1379/studly-frontend
+
+Notes:
+- Example quick run commands (Docker will assign a random container name unless you pass `--name`):
+
+  docker run -d -p 3000:3000 hamed1379/studly-backend:latest
+  docker run -d -p 8080:80 hamed1379/studly-frontend:latest
+
+  On Windows cmd / PowerShell and most shells these commands are identical; use `--name <your-name>` if you prefer a stable container name.
+
+- To see which host ports are mapped after containers are running, use `docker ps` or `docker port <container>`.
+- If you need help with Docker Desktop, try asking the built-in Gordon LLM assistant inside Docker Desktop (search for "Gordon" in the Docker Desktop UI).

--- a/infra/docker/QUICKSTART.md
+++ b/infra/docker/QUICKSTART.md
@@ -87,6 +87,58 @@ Notes:
 - The prod compose pins `INTERNAL_API_TOKEN=studly-local-token` and `STUDLY_USE_MOCK=1` so it works out-of-the-box without a DB.
 - The frontend image baked by CD uses `VITE_API_BASE_URL=http://localhost:3000/api` and sends `x-api-key=studly-local-token`.
 
+## Running images from Docker Hub (quick run)
+If you prefer to pull and run the pre-built images directly from Docker Hub you can use `docker run`.
+
+These examples are intentionally generic: Docker often assigns a random container name when you don't pass `--name` (e.g., `vigorous_jennings`). If you want a predictable container name pass `--name <your-name>`.
+
+- Run the backend (exposes container port 3000 to host port 3000):
+
+Windows cmd / PowerShell / Bash:
+
+```
+docker run -d -p 3000:3000 hamed1379/studly-backend:latest
+```
+
+- Run the frontend (exposes container port 80 to host port 8080):
+
+Windows cmd / PowerShell / Bash:
+
+```
+docker run -d -p 8080:80 hamed1379/studly-frontend:latest
+```
+
+After starting containers you can discover the host port mappings and container names with:
+
+```
+docker ps
+```
+
+Or to inspect a specific container's mapped ports:
+
+```
+docker port <container-id-or-name>
+```
+
+Example notes:
+- Visit the frontend at http://localhost:8080 and the backend at http://localhost:3000.
+- If you used different host ports (for example `-p 5000:3000`) open the corresponding host port.
+- To stop a container:
+
+```
+docker stop <container-id-or-name>
+```
+
+To remove it:
+
+```
+docker rm <container-id-or-name>
+```
+
+### Helpful tips
+- Docker Desktop may show a friendly random container name (like `vigorous_jennings`) when you omit `--name`; this is normal. Use `docker ps` to map name -> ports.
+- If you need help with Docker Desktop, try asking the Gordon LLM assistant inside Docker Desktop (look for "Gordon" in the Docker Desktop UI).
+
 ## Manual steps (Option B only, if you prefer commands)
 1) Create environment files once (only for Option B):
 
@@ -128,7 +180,7 @@ docker compose -f infra/docker/compose.dev.yml up --build
 4) Stop everything:
 
 ```
-docker compose -f infra/docker/compose.dev.yml down -v
+docker compose -f infra\docker\compose.dev.yml down -v
 ```
 
 ## Troubleshooting


### PR DESCRIPTION
## Summary

This PR updates documentation to make Docker usage clearer by explicitly showing port bindings, linking the Docker Quickstart guide, referencing Docker Hub images, and mentioning Docker Desktop's Gordon LLM as an optional helper tool. Examples now clarify container URLs, random naming behavior, and quick image usage.

---

## Changes

### `README.md`

* Added link to `infra/docker/QUICKSTART.md` under the documentation section.
* Introduced a new section **Containerization & Docker Hub**, containing:

  * [https://hub.docker.com/r/hamed1379/studly-backend](https://hub.docker.com/r/hamed1379/studly-backend)
  * [https://hub.docker.com/r/hamed1379/studly-frontend](https://hub.docker.com/r/hamed1379/studly-frontend)
* Included example `docker run` commands demonstrating explicit port bindings:

  ```bash
  docker run -d -p 3000:3000 hamed1379/studly-backend:latest
  docker run -d -p 8080:80 hamed1379/studly-frontend:latest
  ```
* Noted that Docker auto-generates container names (unless `--name` is used).
* Recommended using Gordon LLM within Docker Desktop for troubleshooting and CLI guidance.

### `infra/docker/QUICKSTART.md`

* Added a new section: **Running Images from Docker Hub (Quick Run)**.

  * Backend:

    ```bash
    docker run -d -p 3000:3000 hamed1379/studly-backend:latest
    ```
  * Frontend:

    ```bash
    docker run -d -p 8080:80 hamed1379/studly-frontend:latest
    ```
* Clarified service URLs:

  * Backend: `http://localhost:3000` (`/health` for status)
  * Frontend (Docker image): `http://localhost:8080`
  * Frontend (dev compose): `http://localhost:5173`
* Added tips for inspecting port bindings and container names:

  ```bash
  docker ps
  docker port <container-id-or-name>
  ```
* Mentioned Gordon LLM as a tool available in Docker Desktop for assistance.

