### PR TITLE
Default tests to use Supabase mock

### DIFF
--- a/apps/backend/tests/support/run-jest-lite.js
+++ b/apps/backend/tests/support/run-jest-lite.js
@@ -40,6 +40,13 @@ const projectRoot = resolve(dirname(__filename), '..', '..');
 const testsRoot = join(projectRoot, 'tests');
 
 const args = process.argv.slice(2);
+
+// Ensure the mock Supabase client is always used during test runs, even if real
+// credentials are present in the environment. This prevents integration tests
+// from accidentally hitting live infrastructure or throwing 500s when the
+// database isn't reachable.
+process.env.STUDLY_USE_MOCK = process.env.STUDLY_USE_MOCK ?? '1';
+
 const wantsCoverage = args.includes('--coverage');
 const profilingEnabled = process.env.ENABLE_PROFILING === '1' || process.env.STUDLY_PROFILE === '1';
 const nodeArgs = [];

--- a/apps/backend/tests/unit/internal-api-key.middleware.test.js
+++ b/apps/backend/tests/unit/internal-api-key.middleware.test.js
@@ -57,7 +57,7 @@ test('skips enforcement in test env', () => {
 });
 
 test('returns 500 when token is missing in non-test env', () => {
-  withEnv({ NODE_ENV: 'production' }, () => {
+  withEnv({ NODE_ENV: 'production', STUDLY_USE_MOCK: undefined }, () => {
     const ctx = makeCtx();
     requireInternalApiKey(ctx.req, ctx.res, ctx.next);
     assert.equal(ctx.calledNext, false);
@@ -67,25 +67,31 @@ test('returns 500 when token is missing in non-test env', () => {
 });
 
 test('returns 401 when header missing or mismatched', () => {
-  withEnv({ NODE_ENV: 'production', INTERNAL_API_TOKEN: 'secret-xyz' }, () => {
-    // Missing
-    let ctx = makeCtx();
-    requireInternalApiKey(ctx.req, ctx.res, ctx.next);
-    assert.equal(ctx.calledNext, false);
-    assert.equal(ctx.res._status, 401);
+  withEnv(
+    { NODE_ENV: 'production', INTERNAL_API_TOKEN: 'secret-xyz', STUDLY_USE_MOCK: undefined },
+    () => {
+      // Missing
+      let ctx = makeCtx();
+      requireInternalApiKey(ctx.req, ctx.res, ctx.next);
+      assert.equal(ctx.calledNext, false);
+      assert.equal(ctx.res._status, 401);
 
-    // Mismatched
-    ctx = makeCtx({ 'x-api-key': 'wrong' });
-    requireInternalApiKey(ctx.req, ctx.res, ctx.next);
-    assert.equal(ctx.calledNext, false);
-    assert.equal(ctx.res._status, 401);
-  });
+      // Mismatched
+      ctx = makeCtx({ 'x-api-key': 'wrong' });
+      requireInternalApiKey(ctx.req, ctx.res, ctx.next);
+      assert.equal(ctx.calledNext, false);
+      assert.equal(ctx.res._status, 401);
+    },
+  );
 });
 
 test('calls next() when header matches token', () => {
-  withEnv({ NODE_ENV: 'production', INTERNAL_API_TOKEN: 'secret-abc' }, () => {
-    const ctx = makeCtx({ 'x-api-key': 'secret-abc' });
-    requireInternalApiKey(ctx.req, ctx.res, ctx.next);
-    assert.equal(ctx.calledNext, true);
-  });
+  withEnv(
+    { NODE_ENV: 'production', INTERNAL_API_TOKEN: 'secret-abc', STUDLY_USE_MOCK: undefined },
+    () => {
+      const ctx = makeCtx({ 'x-api-key': 'secret-abc' });
+      requireInternalApiKey(ctx.req, ctx.res, ctx.next);
+      assert.equal(ctx.calledNext, true);
+    },
+  );
 });


### PR DESCRIPTION
## Summary
- default test runs to force the Supabase mock client so integration tests never hit real infrastructure
- update internal API key middleware unit tests to disable the mock when simulating production scenarios

## Testing
- npm test


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691d307a85b0832da80a08eef502f490)