### PR TITLE
fix(leaderboard): correct displayName to use full_name instead of bio

### DIFF
--- a/apps/backend/src/repositories/leaderboard.repository.js
+++ b/apps/backend/src/repositories/leaderboard.repository.js
@@ -20,7 +20,7 @@
  *  friends: id, from_user, to_user, status, updated_at
  *  sessions: id, user_id, start_time, end_time, total_time, date, subject, etc.
  *  user_badge: badge_id, user_id, earned_at
- *  user_profile: user_id, bio
+ *  user_profile: user_id, email, full_name, bio
  *
  *  Design Notes
  *  ------------
@@ -105,7 +105,7 @@ export const createLeaderboardRepository = (client = supabase) => {
    * @param {Array<string>} [options.userIds] - Optional array of user IDs to filter
    * @param {number} [options.limit=7] - Maximum number of results (used as a guideline)
    * @param {string} [options.ensureUserId] - User ID that must be included if they have data
-   * @returns {Promise<Array>} Array of leaderboard entries with user_id, total_minutes, bio
+   * @returns {Promise<Array>} Array of leaderboard entries with user_id, total_minutes, full_name
    * @throws {Error} If query fails
    */
   const findStudyTimeLeaderboard = async ({ userIds: filterUserIds = null, limit = 7, ensureUserId = null }) => {
@@ -149,7 +149,7 @@ export const createLeaderboardRepository = (client = supabase) => {
       if (userIds.length > 0) {
         const { data: profileRows, error: profileError } = await client
           .from('user_profile')
-          .select('user_id, bio')
+          .select('user_id, full_name')
           .in('user_id', userIds);
 
         if (profileError) {
@@ -157,7 +157,7 @@ export const createLeaderboardRepository = (client = supabase) => {
           console.error('[Leaderboard Repository] Failed to fetch user_profile for studyTime leaderboard:', profileError.message);
         } else if (profileRows && profileRows.length > 0) {
           profilesByUserId = profileRows.reduce((acc, row) => {
-            acc[row.user_id] = row.bio || null;
+            acc[row.user_id] = row.full_name || null;
             return acc;
           }, {});
         }
@@ -167,7 +167,7 @@ export const createLeaderboardRepository = (client = supabase) => {
         .map(([userId, totalMinutes]) => ({
           user_id: userId,
           total_minutes: totalMinutes,
-          bio: Object.prototype.hasOwnProperty.call(profilesByUserId, userId)
+          full_name: Object.prototype.hasOwnProperty.call(profilesByUserId, userId)
             ? profilesByUserId[userId]
             : null,
         }))
@@ -202,7 +202,7 @@ export const createLeaderboardRepository = (client = supabase) => {
    * @param {Array<string>} [options.userIds] - Optional array of user IDs to filter
    * @param {number} [options.limit=7] - Maximum number of results (used as a guideline)
    * @param {string} [options.ensureUserId] - User ID that must be included if they have data
-   * @returns {Promise<Array>} Array of leaderboard entries with user_id, badge_count, bio
+   * @returns {Promise<Array>} Array of leaderboard entries with user_id, badge_count, full_name
    * @throws {Error} If query fails
    */
   const findBadgeCountLeaderboard = async ({ userIds: filterUserIds = null, limit = 7, ensureUserId = null }) => {
@@ -244,14 +244,14 @@ export const createLeaderboardRepository = (client = supabase) => {
       if (userIds.length > 0) {
         const { data: profileRows, error: profileError } = await client
           .from('user_profile')
-          .select('user_id, bio')
+          .select('user_id, full_name')
           .in('user_id', userIds);
 
         if (profileError) {
           console.error('[Leaderboard Repository] Failed to fetch user_profile for badge leaderboard:', profileError.message);
         } else if (profileRows && profileRows.length > 0) {
           profilesByUserId = profileRows.reduce((acc, row) => {
-            acc[row.user_id] = row.bio || null;
+            acc[row.user_id] = row.full_name || null;
             return acc;
           }, {});
         }
@@ -261,7 +261,7 @@ export const createLeaderboardRepository = (client = supabase) => {
         .map(([userId, badgeCount]) => ({
           user_id: userId,
           badge_count: badgeCount,
-          bio: Object.prototype.hasOwnProperty.call(profilesByUserId, userId)
+          full_name: Object.prototype.hasOwnProperty.call(profilesByUserId, userId)
             ? profilesByUserId[userId]
             : null,
         }))

--- a/apps/backend/src/services/leaderboard.service.js
+++ b/apps/backend/src/services/leaderboard.service.js
@@ -62,7 +62,7 @@ export const createLeaderboardService = (repository = leaderboardRepository) => 
 
   /**
    * Map database study time leaderboard entry to API format.
-   * @param {object} dbStudyTimeEntry - Raw entry from database (user_id, total_minutes, bio)
+   * @param {object} dbStudyTimeEntry - Raw entry from database (user_id, total_minutes, full_name)
    * @param {string} requestingUserId - UUID of requesting user (for isSelf flag)
    * @returns {object} Entry in API format (camelCase)
    */
@@ -76,7 +76,7 @@ export const createLeaderboardService = (repository = leaderboardRepository) => 
 
     return {
       userId: dbStudyTimeEntry.user_id,
-      displayName: isSelf ? 'You' : (dbStudyTimeEntry.bio || null),
+      displayName: isSelf ? 'You' : (dbStudyTimeEntry.full_name || null),
       totalMinutes: dbStudyTimeEntry.total_minutes,
       isSelf
     };
@@ -84,7 +84,7 @@ export const createLeaderboardService = (repository = leaderboardRepository) => 
 
   /**
    * Map database badge count leaderboard entry to API format.
-   * @param {object} dbBadgeCountEntry - Raw entry from database (user_id, badge_count, bio)
+   * @param {object} dbBadgeCountEntry - Raw entry from database (user_id, badge_count, full_name)
    * @param {string} requestingUserId - UUID of requesting user (for isSelf flag)
    * @returns {object} Entry in API format (camelCase)
    */
@@ -98,7 +98,7 @@ export const createLeaderboardService = (repository = leaderboardRepository) => 
 
     return {
       userId: dbBadgeCountEntry.user_id,
-      displayName: isSelf ? 'You' : (dbBadgeCountEntry.bio || null),
+      displayName: isSelf ? 'You' : (dbBadgeCountEntry.full_name || null),
       badgeCount: dbBadgeCountEntry.badge_count,
       isSelf
     };

--- a/apps/backend/tests/integration/leaderboard.test.js
+++ b/apps/backend/tests/integration/leaderboard.test.js
@@ -74,10 +74,10 @@ const mockUserBadges = [
 ];
 
 const mockProfiles = [
-  { user_id: TEST_USER_ID, bio: 'Test User' },
-  { user_id: TEST_FRIEND_1, bio: 'Friend One' },
-  { user_id: TEST_FRIEND_2, bio: 'Friend Two' },
-  { user_id: TEST_OTHER_USER, bio: 'Top User' }
+  { user_id: TEST_USER_ID, full_name: 'Test User' },
+  { user_id: TEST_FRIEND_1, full_name: 'Friend One' },
+  { user_id: TEST_FRIEND_2, full_name: 'Friend Two' },
+  { user_id: TEST_OTHER_USER, full_name: 'Top User' }
 ];
 
 let server;

--- a/apps/backend/tests/unit/leaderboard.service.test.js
+++ b/apps/backend/tests/unit/leaderboard.service.test.js
@@ -47,12 +47,12 @@ test('getLeaderboards - should return all four leaderboards with correct structu
   const mockRepo = createMockRepository({
     findAcceptedFriendsForUser: async () => [MOCK_FRIEND_ID_1, MOCK_FRIEND_ID_2],
     findStudyTimeLeaderboard: async () => [
-      { user_id: MOCK_FRIEND_ID_1, total_minutes: 1000, bio: 'Friend One' },
-      { user_id: MOCK_USER_ID, total_minutes: 500, bio: 'Me' }
+      { user_id: MOCK_FRIEND_ID_1, total_minutes: 1000, full_name: 'Friend One' },
+      { user_id: MOCK_USER_ID, total_minutes: 500, full_name: 'Me' }
     ],
     findBadgeCountLeaderboard: async () => [
-      { user_id: MOCK_FRIEND_ID_2, badge_count: 15, bio: 'Friend Two' },
-      { user_id: MOCK_USER_ID, badge_count: 10, bio: 'Me' }
+      { user_id: MOCK_FRIEND_ID_2, badge_count: 15, full_name: 'Friend Two' },
+      { user_id: MOCK_USER_ID, badge_count: 10, full_name: 'Me' }
     ]
   });
 
@@ -77,10 +77,10 @@ test('getLeaderboards - should mark requesting user with isSelf=true and display
   const mockRepo = createMockRepository({
     findAcceptedFriendsForUser: async () => [],
     findStudyTimeLeaderboard: async () => [
-      { user_id: MOCK_USER_ID, total_minutes: 500, bio: 'My Bio' }
+      { user_id: MOCK_USER_ID, total_minutes: 500, full_name: 'My Bio' }
     ],
     findBadgeCountLeaderboard: async () => [
-      { user_id: MOCK_USER_ID, badge_count: 10, bio: 'My Bio' }
+      { user_id: MOCK_USER_ID, badge_count: 10, full_name: 'My Bio' }
     ]
   });
 
@@ -101,9 +101,9 @@ test('getLeaderboards - should add sequential rankings starting from 1', async (
   const mockRepo = createMockRepository({
     findAcceptedFriendsForUser: async () => [MOCK_FRIEND_ID_1, MOCK_FRIEND_ID_2],
     findStudyTimeLeaderboard: async () => [
-      { user_id: MOCK_FRIEND_ID_1, total_minutes: 1000, bio: 'First' },
-      { user_id: MOCK_FRIEND_ID_2, total_minutes: 800, bio: 'Second' },
-      { user_id: MOCK_USER_ID, total_minutes: 600, bio: 'Third' }
+      { user_id: MOCK_FRIEND_ID_1, total_minutes: 1000, full_name: 'First' },
+      { user_id: MOCK_FRIEND_ID_2, total_minutes: 800, full_name: 'Second' },
+      { user_id: MOCK_USER_ID, total_minutes: 600, full_name: 'Third' }
     ],
     findBadgeCountLeaderboard: async () => []
   });
@@ -132,7 +132,7 @@ test('getLeaderboards - should map study time fields correctly to camelCase', as
   const mockRepo = createMockRepository({
     findAcceptedFriendsForUser: async () => [],
     findStudyTimeLeaderboard: async () => [
-      { user_id: MOCK_FRIEND_ID_1, total_minutes: 1234.56, bio: 'Test User' }
+      { user_id: MOCK_FRIEND_ID_1, total_minutes: 1234.56, full_name: 'Test User' }
     ],
     findBadgeCountLeaderboard: async () => []
   });
@@ -153,7 +153,7 @@ test('getLeaderboards - should map badge count fields correctly to camelCase', a
     findAcceptedFriendsForUser: async () => [],
     findStudyTimeLeaderboard: async () => [],
     findBadgeCountLeaderboard: async () => [
-      { user_id: MOCK_FRIEND_ID_1, badge_count: 42, bio: 'Badge Master' }
+      { user_id: MOCK_FRIEND_ID_1, badge_count: 42, full_name: 'Badge Master' }
     ]
   });
 
@@ -168,11 +168,11 @@ test('getLeaderboards - should map badge count fields correctly to camelCase', a
   assert.strictEqual(entry.isSelf, false);
 });
 
-test('getLeaderboards - should handle null bio by returning null displayName', async () => {
+test('getLeaderboards - should handle null full_name by returning null displayName', async () => {
   const mockRepo = createMockRepository({
     findAcceptedFriendsForUser: async () => [],
     findStudyTimeLeaderboard: async () => [
-      { user_id: MOCK_FRIEND_ID_1, total_minutes: 500, bio: null }
+      { user_id: MOCK_FRIEND_ID_1, total_minutes: 500, full_name: null }
     ],
     findBadgeCountLeaderboard: async () => []
   });
@@ -189,7 +189,7 @@ test('getLeaderboards - should include requesting user even with no friends', as
   const mockRepo = createMockRepository({
     findAcceptedFriendsForUser: async () => [],
     findStudyTimeLeaderboard: async () => [
-      { user_id: MOCK_USER_ID, total_minutes: 100, bio: 'Solo' }
+      { user_id: MOCK_USER_ID, total_minutes: 100, full_name: 'Solo' }
     ],
     findBadgeCountLeaderboard: async () => []
   });


### PR DESCRIPTION
## Summary

This PR fixes an issue where the leaderboard API returned the `bio` field as the `displayName` instead of the correct `full_name` value from `user_profile`.

---

## Changes

### Repository Layer (`leaderboard.repository.js`)

* Updated study time and badge count queries to fetch `full_name` instead of `bio`.
* Updated schema references and JSDoc comments.

### Service Layer (`leaderboard.service.js`)

* Updated `mapStudyTimeEntryToApi()` to map `full_name` to `displayName`.
* Updated `mapBadgeCountEntryToApi()` accordingly.
* Updated JSDoc comments for clarity.

### Tests

* Updated unit tests in `leaderboard.service.test.js` to expect `full_name`.
* Updated integration tests in `leaderboard.test.js` to use `full_name`.
* All **134 backend tests** passing.
* Manual endpoint verification confirms correct display names.

---

## Result

The leaderboard endpoint now correctly returns each user's `full_name` as the `displayName`, ensuring accurate and consistent rendering in the UI.
